### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Compress/Zlib/Raw.pm6
+++ b/lib/Compress/Zlib/Raw.pm6
@@ -1,5 +1,5 @@
 use v6;
-module Compress::Zlib::Raw;
+unit module Compress::Zlib::Raw;
 
 use NativeCall;
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.