### PR TITLE
Remove Panda::Builder dependency

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -1,12 +1,10 @@
-use Panda::Builder;
-
 use Shell::Command;
 use NativeCall;
 
 # test sub for system library
 our sub zlibVersion() returns Str is encoded('ascii') is native('zlib1.dll') is export { * }
 
-class Build is Panda::Builder {
+class Build {
     method build($workdir) {
         my $need-copy = False;
 
@@ -29,4 +27,6 @@ class Build is Panda::Builder {
             say 'Found system zlib library.';
         }
     }
+
+    method isa($what) { return True if $what.^name eq 'Panda::Builder'; callsame }
 }

--- a/META.info
+++ b/META.info
@@ -4,6 +4,7 @@
     "author" : "github:retupmoca",
     "description" : "Low-level bindings to zlib",
     "depends" : ["Find::Bundled"],
+    "build-depends" : ["Shell::Command"],
     "provides" : {
         "Compress::Zlib::Raw" : "lib/Compress/Zlib/Raw.pm6"
     },


### PR DESCRIPTION
`Panda::Builder` itself serves no purpose to the build process, so lets trick panda into thinking its a `Panda::Builder` without ever having to actually load it. This allows manual installation or for alternative package managers to install it without installing `panda`

Reference: https://github.com/ugexe/zef/issues/68