### PR TITLE
Use libz.dylib on Mac OS

### DIFF
--- a/lib/Compress/Zlib/Raw.pm6
+++ b/lib/Compress/Zlib/Raw.pm6
@@ -12,6 +12,8 @@ sub find-lib {
             $lib = Find::Bundled.find('zlib1.dll', 'Compress/Zlib', :keep-filename, :return-original);
         } elsif $*VM.config<dll> ~~ /so$/ {
             $lib = 'libz.so.1';
+        } elsif $*VM.config<dll> ~~ /dylib$/ {
+            $lib = 'libz.dylib';
         } else {
             $lib = 'libz';
         }


### PR DESCRIPTION
On Mac OS X environment, the "libz" library file name is `libz.dylib`, and I'm getting an error as:

    Cannot locate native library 'libz': dlopen(libz, 1): image not found
        in method setup at /Users/yowcow/.rakudobrew/moar-nom/install/share/perl6/sources/075EFE4B4CDAAF73190194EA876F81A1F128D1A2 line 261
        in method CALL-ME at /Users/yowcow/.rakudobrew/moar-nom/install/share/perl6/sources/075EFE4B4CDAAF73190194EA876F81A1F128D1A2 line 272
        in block <unit> at t/01-basic.t line 11

This patch fixes the issue by specifying correct library "libz.dylib" in such environment that `$*VM.config<dll>` is `lib%s.dylib`.