### PR TITLE
Replace Str arg to RESOURCES with key

### DIFF
--- a/lib/Compress/Zlib/Raw.pm6
+++ b/lib/Compress/Zlib/Raw.pm6
@@ -8,7 +8,7 @@ sub find-lib {
     unless $lib {
         if $*VM.config<dll> ~~ /dll/ {
             # we're on windows, different library name
-            $lib = ~(%?RESOURCES{"zlib1.dll"});
+            $lib = %?RESOURCES<zlib1.dll>.IO.absolute;
         } elsif $*VM.config<dll> ~~ /so$/ {
             $lib = 'libz.so.1';
         } elsif $*VM.config<dll> ~~ /dylib$/ {


### PR DESCRIPTION
Passing a string to the `%?RESOURCES` hash (and then having it point to an `IO::Path` internally) [may unexpectedly
return inconsistent values depending on the compilation stage](https://github.com/rakudo/rakudo/pull/5505).  As such, the `Str` behaviour has been deprecated.  See also:

  - https://github.com/rakudo/rakudo/pull/5505
  - https://github.com/rakudo/rakudo/issues/5504
  - https://github.com/rakudo/rakudo/pull/5507

for more background information.

This change only became apparent after testing the code on Windows (as that is the only code path using `%?RESOURCES` to find the dynamically linked library).  The deprecation notice was:

```
Method Str (from Distribution::Resource) seen at:
  'SETTING::'src/core.c/Mu.rakumod, line 807

Please use %?RESOURCES<key> directly instead.
```

hence the motivation for this commit.

Note also that the original call was used in a string context, hence the deprecation notice still appeared.  Since the desired string was the absolute path to the `zlib1.dll` file, the solution was to get the absolute path of the `IO::Path` object corresponding to the `Distribution::Resource` object specified by `%$RESOURCES`.